### PR TITLE
Disable tracing with zbio message broker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,8 +38,6 @@ build-client:
 dockerise:
 	docker build -t ${CLIENT_IMG}:${IMAGE_TAG} -f client.Dockerfile .
 	docker build -t ${SERVER_IMG}:${IMAGE_TAG} -f server.Dockerfile .	
-	${shell pwd}/../push_image.sh "${CLIENT_IMG}:${IMAGE_TAG}"
-	${shell pwd}/../push_image.sh "${SERVER_IMG}:${IMAGE_TAG}"
 
 .PHONY: deploy
 deploy:

--- a/kubernetes/deploy.yaml
+++ b/kubernetes/deploy.yaml
@@ -31,11 +31,10 @@ spec:
     spec:
       containers:
       - name: server
-        image: server:latest
+        image: roost-utility:5002/server:latest
         env:
         - name: SERVICE_ADDRESS
           value: zbio-service.zbio:50002
-        imagePullPolicy: Never
         ports:
         - containerPort: 3000
         livenessProbe:
@@ -51,9 +50,7 @@ spec:
           # The periodSeconds field specifies that the kubelet should perform a readiness probe every X seconds. 
           periodSeconds: 1
       - name: client
-        image: client:latest
+        image: roost-utility:5002/client:latest
         env:
         - name: SERVICE_ADDRESS
           value: zbio-service.zbio:50002
-        # Since we push image to `minikube docker-env` we want it to pull locally and not from dokcer hub. 
-        imagePullPolicy: Never

--- a/message/zbio.go
+++ b/message/zbio.go
@@ -11,7 +11,7 @@ const (
 	// TopicName to be created in zbio
 	TopicName string = "grpc-healthcheck-example"
 	// ZBIOEnabled specifies whether zbio messaging is enabled
-	zbioEnabled bool = true
+	zbioEnabled bool = false
 )
 
 var (
@@ -54,6 +54,9 @@ func InitZBIO(cfg zb.Config) {
 
 // SendMessageToZBIO sends message to zbio
 func SendMessageToZBIO(messages []zb.Message) {
+	if !zbioEnabled {
+		return
+	}
 	// send messages only if topic exists zbClient.DescribeTopics([]string{topicName})
 	var topicFound = true
 	if topicFound {


### PR DESCRIPTION
- ZBIO messaging broker service might not have deployed in the the cluster so disabled tracing via ZBIO broker.